### PR TITLE
Pods 9032 - Downgrading .warn to .info in cases where no error has occured

### DIFF
--- a/app/connectors/AFTConnector.scala
+++ b/app/connectors/AFTConnector.scala
@@ -57,11 +57,11 @@ class AFTConnector @Inject()(http: HttpClient, config: FrontendAppConfig)
                    (implicit ec: ExecutionContext, hc: HeaderCarrier): Future[JsValue] = {
     val url = config.getAftDetails
     val aftHc = hc.withExtraHeaders(headers = "pstr" -> pstr, "startDate" -> startDate, "aftVersion" -> aftVersion)
-    logger.info(s"Calling getAFT details")
+    logger.info("Calling getAFT details")
     http.GET[HttpResponse](url)(implicitly, aftHc, implicitly).map { response =>
       response.status match {
         case OK =>
-          logger.info(s"GetAFT details returned response with status OK")
+          logger.info("GetAFT details returned response with status OK")
           Json.parse(response.body)
         case _ =>
           logger.warn(s"GetAFT details returned response with status ${response.status}")

--- a/app/connectors/AFTConnector.scala
+++ b/app/connectors/AFTConnector.scala
@@ -57,12 +57,15 @@ class AFTConnector @Inject()(http: HttpClient, config: FrontendAppConfig)
                    (implicit ec: ExecutionContext, hc: HeaderCarrier): Future[JsValue] = {
     val url = config.getAftDetails
     val aftHc = hc.withExtraHeaders(headers = "pstr" -> pstr, "startDate" -> startDate, "aftVersion" -> aftVersion)
-    logger.warn(s"Calling getAFT details")
+    logger.info(s"Calling getAFT details")
     http.GET[HttpResponse](url)(implicitly, aftHc, implicitly).map { response =>
-      logger.warn(s"GetAFT details resturned response with status ${response.status}")
       response.status match {
-        case OK => Json.parse(response.body)
-        case _ => handleErrorResponse("GET", url)(response)
+        case OK =>
+          logger.info(s"GetAFT details returned response with status OK")
+          Json.parse(response.body)
+        case _ =>
+          logger.warn(s"GetAFT details returned response with status ${response.status}")
+          handleErrorResponse("GET", url)(response)
       }
     } andThen {
       case Failure(t: Throwable) => logger.warn("Unable to get aft details", t)

--- a/app/connectors/cache/FileUploadCacheConnector.scala
+++ b/app/connectors/cache/FileUploadCacheConnector.scala
@@ -69,8 +69,9 @@ class FileUploadCacheConnector @Inject()(
     http.POST[JsValue, HttpResponse](url, Json.toJson(fileReference))(implicitly, implicitly, hc, implicitly)
       .map { response =>
         response.status match {
-          case OK => logger.warn(s"requestUpload for uploadId ${uploadId.value} return response with status ${response.status}")
+          case OK => logger.info(s"requestUpload for uploadId ${uploadId.value} return response with status OK")
           case _ =>
+            logger.warn(s"requestUpload for uploadId ${uploadId.value} return response with status ${response.status}")
             throw new HttpException(response.body, response.status)
         }
       }
@@ -89,8 +90,9 @@ class FileUploadCacheConnector @Inject()(
     http.POST[JsValue, HttpResponse](urlUploadResult, Json.toJson(status))(implicitly, implicitly, hc, implicitly)
       .map { response =>
         response.status match {
-          case OK => logger.warn(s"registerUploadResult for Reference ${reference.reference} return response with status ${response.status}")
+          case OK => logger.info(s"registerUploadResult for Reference ${reference.reference} return response with status OK")
           case _ =>
+            logger.warn(s"registerUploadResult for Reference ${reference.reference} return response with status ${response.status}")
             throw new HttpException(response.body, response.status)
         }
       }

--- a/app/controllers/AFTSummaryController.scala
+++ b/app/controllers/AFTSummaryController.scala
@@ -73,7 +73,7 @@ class AFTSummaryController @Inject()(
       allowAccess(srn, startDate, optionPage = Some(AFTSummaryPage), version, accessType)).async { implicit request =>
       Try(request.userAnswers.data \ "chargeEDetails" \ "members" \\ "memberDetails") match {
         case Success(value) =>
-          logger.warn(s"Loading aft summary page: success getting member details: size = ${value.size}")
+          logger.info(s"Loading aft summary page: success getting member details: size = ${value.size}")
         case _ => ()
       }
 
@@ -102,7 +102,7 @@ class AFTSummaryController @Inject()(
     (identify andThen getData(srn, startDate) andThen requireData andThen
       allowAccess(srn, startDate, optionPage = Some(AFTSummaryPage), version, accessType)).async { implicit request =>
 
-      logger.warn("AFT summary controller on search member")
+      logger.info("AFT summary controller on search member")
 
       schemeService.retrieveSchemeDetails(
         psaId = request.idOrException,
@@ -116,14 +116,14 @@ class AFTSummaryController @Inject()(
             formWithErrors => {
               logger.warn("AFT summary controller on search member -- errors")
               val json = getJson(form, formWithErrors, ua, srn, startDate, schemeDetails.schemeName, version, accessType)
-              logger.warn(s"AFT summary controller on search member -- got json")
+              logger.warn("AFT summary controller on search member -- got json")
               renderer.render(template = nunjucksTemplate, json).map(BadRequest(_))
             },
             value => {
-              logger.warn(s"AFT summary controller on search member -- value = $value - about to search")
+              logger.info(s"AFT summary controller on search member -- value = $value - about to search")
               val preparedForm: Form[String] = memberSearchForm.fill(value)
               val searchResults = memberSearchService.search(ua, srn, startDate, value, accessType, version)
-              logger.warn(s"AFT summary controller on search member -- searchResults size = ${searchResults.size}")
+              logger.info(s"AFT summary controller on search member -- searchResults size = ${searchResults.size}")
               val json =
                 getJsonCommon(form, preparedForm, srn, startDate, schemeDetails.schemeName, version, accessType) ++
                   Json.obj("list" -> Json.toJson(searchResults)) ++

--- a/app/controllers/actions/DataRetrievalAction.scala
+++ b/app/controllers/actions/DataRetrievalAction.scala
@@ -41,7 +41,7 @@ class DataRetrievalImpl(
   override protected def transform[A](request: IdentifierRequest[A]): Future[OptionalDataRequest[A]] = {
     implicit val hc: HeaderCarrier = HeaderCarrierConverter.fromRequestAndSession(request, request.session)
     val id = s"$srn$startDate"
-    logger.warn("Dataretrieval action transform - start")
+    logger.info("Dataretrieval action transform - start")
     val result = for {
       data <- userAnswersCacheConnector.fetch(id)
       sessionData <- userAnswersCacheConnector.getSessionData(id)
@@ -49,7 +49,7 @@ class DataRetrievalImpl(
       val optionUA = data.map(jsValue => UserAnswers(jsValue.as[JsObject]))
       OptionalDataRequest[A](request, id, request.psaId, request.pspId, optionUA, sessionData)
     }
-    logger.warn("Dataretrieval action transform - end")
+    logger.info("Dataretrieval action transform - end")
     result andThen {
       case Success(v) => logger.info("Successful response to data retrieval:" + v)
       case Failure(t: Throwable) => logger.warn("Unable to complete dataretrieval", t)

--- a/app/controllers/financialOverview/scheme/PaymentsAndChargesController.scala
+++ b/app/controllers/financialOverview/scheme/PaymentsAndChargesController.scala
@@ -76,7 +76,7 @@ class PaymentsAndChargesController @Inject()(
             )
             renderer.render(template = "financialOverview/scheme/paymentsAndCharges.njk", json).map(Ok(_))
         } else {
-          logger.warn(s"Empty payments cache")
+          logger.warn("Empty payments cache")
           Future.successful(Redirect(controllers.routes.SessionExpiredController.onPageLoad))
         }
       }

--- a/app/fileUploadParsers/FileLogWriter.scala
+++ b/app/fileUploadParsers/FileLogWriter.scala
@@ -27,7 +27,7 @@ object TimeLogger {
     val start = System.currentTimeMillis
     val call = f
     val totalTime = System.currentTimeMillis() - start
-    logger.warn(s"FileUpload logging time $description is $totalTime ms")
+    logger.info(s"FileUpload logging time $description is $totalTime ms")
     call
   }
 

--- a/app/services/RequestCreationService.scala
+++ b/app/services/RequestCreationService.scala
@@ -55,12 +55,12 @@ class RequestCreationService @Inject()(
                                  ): Future[OptionalDataRequest[A]] = {
 
     val id = s"$srn$startDate"
-    logger.warn("Entered retrieveAndCreateRequest method 1")
+    logger.info("Entered retrieveAndCreateRequest method 1")
     userAnswersCacheConnector.fetch(id).flatMap { data =>
 
           val optionUA = data.map { jsValue => UserAnswers(jsValue.as[JsObject]) }
           if(optionUA.nonEmpty) {
-            logger.warn(s"Some data found in cache for ${optionCurrentPage.getOrElse("unrecognised page")}")
+            logger.info(s"Some data found in cache for ${optionCurrentPage.getOrElse("unrecognised page")}")
           } else {
             logger.warn(s"No data found in cache but user in default case for ${optionCurrentPage.getOrElse("unrecognised page")}")
           }
@@ -160,20 +160,20 @@ class RequestCreationService @Inject()(
           .setOrException(SchemeNameQuery, schemeDetails.schemeName)
           .setOrException(PSTRQuery, schemeDetails.pstr))
     } else {
-      logger.warn("seqAFTOverview non empty - getAftDetails will be called")
+      logger.info("seqAFTOverview non empty - getAftDetails will be called")
       val isCompilable = seqAFTOverview.headOption.map(_.compiledVersionAvailable)
 
       val updatedVersion = (accessType, isCompilable) match {
         case (Draft, Some(false)) =>
           if (version == 1) {
-            logger.warn("Version is 1 so will derive a zero so leave at 1. seqAFTOverview=" + seqAFTOverview)
+            logger.info("Version is 1 so will derive a zero so leave at 1. seqAFTOverview=" + seqAFTOverview)
             version
           } else {
             version - 1
           }
         case _ => version
       }
-      logger.warn(s"seqAFTOverview non empty - getAftDetails will be called for version $updatedVersion")
+      logger.info(s"seqAFTOverview non empty - getAftDetails will be called for version $updatedVersion")
       aftConnector
         .getAFTDetails(schemeDetails.pstr, startDate, updatedVersion.toString)
         .map { aftDetails =>


### PR DESCRIPTION
Code:
- Removed instances in the code where `.warn` was being used incorrectly in cases where `.info` is sufficient. This will declutter our logs to be a more accurate reflection of the status of AFT FE.